### PR TITLE
Fix !pt MTRR Format Specifier

### DIFF
--- a/UefiDbgExt/pt.cpp
+++ b/UefiDbgExt/pt.cpp
@@ -881,7 +881,7 @@ PrintAddress:
   PhysicalAddress += PageOffset;
 
   // Get the cache type from MTRRs
-  CacheType = MonitorCommandWithOutput (Client, Format ("arch mtrr %X", Address).c_str (), 0);
+  CacheType = MonitorCommandWithOutput (Client, Format ("arch mtrr %llX", Address).c_str (), 0);
 
   // if CacheType has spaces in it, it means the monitor command didn't exist
   if (strchr (CacheType, ' ') != NULL) {


### PR DESCRIPTION
For x86 targets, running !pt <addr> could incorrectly print the cache type from MTRRs because it was using the %X format specifier to get the address string to send to the mtrr monitor command. This truncated the address to 32 bits. This is resolved by using %llX.