### PR TITLE
CI: Always run Build-UefiExt workflow on PRs and pushes

### DIFF
--- a/.github/workflows/Build-UefiExt.yaml
+++ b/.github/workflows/Build-UefiExt.yaml
@@ -12,12 +12,8 @@ on:
   workflow_dispatch:
   push:
     branches: [ main ]
-    paths:
-      - 'UefiDbgExt/**'
   pull_request:
     branches: [ main ]
-    paths:
-      - 'UefiDbgExt/**'
   release:
     types: [published]
 


### PR DESCRIPTION
This is marked as a mandatory pipeline, so always run it even if no files are changed in the extension. The CI pipeline will need more work as more items come online, but this will prevent blocking PRs in the meantime.