### PR TITLE
[REBASE & FF] Various Fixes

### DIFF
--- a/Scripts/ComToTcpServer.py
+++ b/Scripts/ComToTcpServer.py
@@ -88,6 +88,12 @@ _line_buffer_in = ""
 _line_buffer_out = ""
 
 
+def clear_queue(q: queue.Queue) -> None:
+    """Remove all pending items from a queue."""
+    while not q.empty():
+        q.get()
+
+
 def socket_thread() -> None:
     """Thread function that handles TCP socket connections.
 
@@ -108,9 +114,8 @@ def socket_thread() -> None:
         conn, addr = sock.accept()
         script_logger.info(f"Socket Connected - {addr}")
 
-        # clear the out queue before starting a connection
-        while not out_queue.empty():
-            out_queue.get()
+        # Clear pending socket output before starting a new connection.
+        clear_queue(out_queue)
 
         # use a short timeout to move on if no data is ready.
         conn.settimeout(0.01)
@@ -127,6 +132,15 @@ def socket_thread() -> None:
                 data = None
             except Exception:
                 script_logger.info("Socket disconnected.")
+                clear_queue(out_queue)
+                conn.close()
+                connected = False
+                continue
+
+            if data is not None and len(data) == 0:
+                script_logger.info("Socket disconnected.")
+                clear_queue(out_queue)
+                conn.close()
                 connected = False
                 continue
 

--- a/patina-ext/src/commands/index.ts
+++ b/patina-ext/src/commands/index.ts
@@ -22,11 +22,10 @@ namespace Commands {
 //   - io: Dump the GCD I/O map with details about each I/O block.
 //   - help: Show a help message describing the available subcommands and their usage.
 function __gcd(cmd: any) {
-  if (globalThis.PATINA_MODULE === null) {
-    host.diagnostics.debugLog("Patina Core module not found.\n");
-    return;
+  const module = getModule("patina_dxe_core::GCD");
+  if (!module) {
+    return "Failed to locate Patina module.";
   }
-  const module = globalThis.PATINA_MODULE;
 
   if (cmd === "memory") {
     const query = [

--- a/patina-ext/src/commands/index.ts
+++ b/patina-ext/src/commands/index.ts
@@ -69,9 +69,9 @@ function __gcd(cmd: any) {
         "  io        - Dump the GCD I/O map with details about each I/O block.\n" +
         "  help      - Show this help message.\n" +
         "\nExample Usage:\n" +
-        '  !gcd "memory"\n' +
-        '  !gcd "io"\n' +
-        '  !gcd "help"\n',
+        "  !gcd memory\n" +
+        "  !gcd io\n" +
+        "  !gcd help\n",
     );
     return;
   }

--- a/patina-ext/src/global.ts
+++ b/patina-ext/src/global.ts
@@ -8,6 +8,3 @@
 
 // Global variable representing the current version of the extension.
 declare var APP_VERSION: string;
-
-// Global variable representing the name of the module containing the Patina Core (`patina_dxe_core`).
-declare var PATINA_MODULE: string | null;

--- a/patina-ext/src/index.ts
+++ b/patina-ext/src/index.ts
@@ -25,9 +25,5 @@ function initializeScript(): any[] {
 // Perform environment detection and initialization of global variables used across the extension
 function initialize(): string {
   globalThis.APP_VERSION = "0.1.0";
-  globalThis.PATINA_MODULE = getModule("patina_dxe_core::GCD");
-  if (!globalThis.PATINA_MODULE) {
-    return "Failed to locate Patina module.";
-  }
   return "Patina extension initialized.";
 }

--- a/patina-ext/src/visualizers/collections.ts
+++ b/patina-ext/src/visualizers/collections.ts
@@ -76,7 +76,9 @@ namespace Visualizers.Collections {
           current = current.left_node;
         }
         current = stack.pop()!;
-        yield current.data;
+        // Patina's node data is wrapped in MaybeUninit, so we
+        // need to access the value field to get the actual data.
+        yield current.data.value;
         current = current.right_node;
       }
     }


### PR DESCRIPTION
ComToTcpServer: Flush Buffers When Client Drops
--
When a socket client drops, e.g. WinDbg disconnects, stale data is left in the buffer. When the client reconnects, the stale data causes the connection to fail.

This amends that behavior to clear the buffers when a client drops. After this change, the script can be left running and WinDbg can be disconnected and reconnected without issue.

JS Ext: Fetch Patina Module On Demand
--
Currently, the JS ext tries to cache the Patina module on init. This does not work for two reasons:
- We may not have symbols on the initialization and so the JS init fails.
- We may load a new Patina DXE Core and so cannot keep a reference to the old core.

Both of these issues are fixed by simply getting the module on invocation of !gcd without any difference in perf (same module lookup or using WinDbg's caching).

JS Ext: !gcd: Account for MaybeUninit Type
--
Patina's Node structure was changed in v21.0.2 to have a MaybeUninit wrapping all the data. This causes !gcd to fail because the expected types are not there.

This is fixed by updating the node iterator to remove the MaybeUninit before yielding a new node.

This also fixes the help to drop the unneccessary quotes.