### PR TITLE
Workflows: Add GitHub Action workflow for packaging scripts.

### DIFF
--- a/.github/workflows/Package-Scripts.yaml
+++ b/.github/workflows/Package-Scripts.yaml
@@ -1,0 +1,55 @@
+#
+# GitHub Action Workflow for packaging scripts.
+#
+# Copyright (c) Microsoft Corporation
+#
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+
+name: "Package Scripts"
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  release:
+    types: [published]
+
+jobs:
+  build-scripts:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: x64
+            runs-on: windows-2022
+          - platform: arm64
+            runs-on: windows-11-arm
+    runs-on: ${{ matrix.runs-on }}
+    permissions:
+      contents: write
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          architecture: ${{ matrix.platform }}
+
+      - name: Install dependencies
+        run: pip install -r pip-requirements.txt
+
+      - name: Build ComToTcpServer binary
+        run: pyinstaller --onefile --name ComToTcpServer Scripts\ComToTcpServer.py
+
+      - name: Publish Release Asset
+        if: ${{ github.event_name == 'release' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          Compress-Archive -Path dist\ComToTcpServer.exe -DestinationPath Scripts_${{ matrix.platform }}.zip
+          gh release upload ${{ github.event.release.tag_name }} Scripts_${{ matrix.platform }}.zip

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,8 @@ EfiSymComposition/ARM64/
 EfiSymComposition/packages/
 EfiSymComposition/.vs/
 EfiSymComposition/EfiSymComposition.vcxproj.user
+
+# Pyinstaller Build
+build/
+dist/
+*.spec

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -1,0 +1,14 @@
+## @file
+# PIP dependencies for python scripts in this project.
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+# https://pypi.org/project/pip/
+# https://pip.pypa.io/en/stable/user_guide/#requirements-files
+# https://pip.pypa.io/en/stable/reference/requirements-file-format
+# https://www.python.org/dev/peps/pep-0440/#version-specifiers
+##
+pyserial==3.5
+pywin32==308
+pyinstaller==6.11.1


### PR DESCRIPTION
This commit adds a workflow that will package scripts into a single executable for releases. This is mostly for convenience to allow the tools to be easier and more portable for users. The raw script are still going to be more flexible for common use.