### PR TITLE
Update GCD Visualizer for patina_internal_core

### DIFF
--- a/patina-ext/src/visualizers/collections.ts
+++ b/patina-ext/src/visualizers/collections.ts
@@ -8,11 +8,11 @@ namespace Visualizers.Collections {
     return [
       new host.typeSignatureRegistration(
         Tree,
-        "patina_internal_collections::rbt::Rbt<*>",
+        "patina_internal_core::collections::rbt::Rbt<*>",
       ),
       new host.typeSignatureRegistration(
         Node,
-        "patina_internal_collections::node::Node<*>",
+        "patina_internal_core::collections::node::Node<*>",
       ),
     ];
   }


### PR DESCRIPTION
Patina v22.2.0 removed the patina_internal_collections crate in favor the patina_internal_core crate. This requires an update in the visualizer.